### PR TITLE
Use AWS region when validating token

### DIFF
--- a/cognito_jwt_validator.go
+++ b/cognito_jwt_validator.go
@@ -44,7 +44,7 @@ func (config *Config) Validate(jwtToken string) error {
 		return errors.New("TOKEN IS FROM A DIFFERENT client_id")
 	}
 
-	if parsedToken.Issuer() != fmt.Sprintf("https://cognito-idp.us-east-2.amazonaws.com/%s", config.CognitoPoolId) {
+	if parsedToken.Issuer() != fmt.Sprintf("https://cognito-idp.%s.amazonaws.com/%s", config.Region, config.CognitoPoolId) {
 		return errors.New("TOKEN IS FROM A DIFFERENT pool_id")
 	}
 


### PR DESCRIPTION
Current code only works for the hard coded AWS region, I just added a simple string substitution to use the Region variable in the config. Tested locally with region eu-west-1.